### PR TITLE
Fix: Ensure dark mode persists across pages

### DIFF
--- a/country.js
+++ b/country.js
@@ -54,9 +54,10 @@ fetch(`https://restcountries.com/v3.1/name/${countryName}?fullText=true`)
   darkModeToggle.addEventListener("click", () =>{
     document.body.classList.toggle("dark-mode-body");
     document.querySelector(".header-container").classList.toggle("dark-mode-header");
-
+    const isDarkMode=document.body.classList.contains("dark-mode-body")
+    localStorage.setItem("darkMode", isDarkMode ? "on" : "off")
     const darkModeicon = document.querySelector(".dark-mode-btn i");
-    if(document.body.classList.contains("dark-mode-body")){
+    if(isDarkMode){
       darkModeicon.classList.replace("bi-moon-fill", "bi-sun-fill");
       darkModeToggle.innerHTML = `<i class="bi bi-sun-fill"></i>&nbsp;&nbsp;Light Mode`;
     }
@@ -64,9 +65,15 @@ fetch(`https://restcountries.com/v3.1/name/${countryName}?fullText=true`)
       darkModeicon.classList.replace("bi-sun-fill", "bi-moon-fill");
       darkModeToggle.innerHTML = `<i class="bi bi-moon-fill"></i>&nbsp;&nbsp;Dark Mode`;
     }
-
     });
 
-
-
-  
+    window.addEventListener('load',()=>{
+      const darkModeState=localStorage.getItem("darkMode")
+      if(darkModeState==="on"){
+        document.body.classList.add("dark-mode-body");
+    document.querySelector(".header-container").classList.add("dark-mode-header");
+    const darkModeicon = document.querySelector(".dark-mode-btn i");
+    darkModeicon.classList.replace("bi-moon-fill", "bi-sun-fill");
+      darkModeToggle.innerHTML = `<i class="bi bi-sun-fill"></i>&nbsp;&nbsp;Light Mode`;
+      }
+    })

--- a/script.js
+++ b/script.js
@@ -55,19 +55,18 @@ searchInput.addEventListener("input", ((e) => {
 }))
 
 darkModeToggle.addEventListener("click", () => {
-
+//fixing dark-mode
   document.body.classList.toggle("dark-mode-body");
   document.querySelector(".header-container").classList.toggle("dark-mode-header");
-
-
   const countryCards = document.querySelectorAll(".country-card");
   countryCards.forEach(card => {
     card.classList.toggle("dark-mode-card");
 
   });
-
+  const isDarkMode=document.body.classList.contains("dark-mode-body");
+  localStorage.setItem("darkMode", isDarkMode ? "on" : "off");
   const icon = darkModeToggle.querySelector("i");
-  if (document.body.classList.contains("dark-mode-body")) {
+  if (isDarkMode) {
     icon.classList.replace("bi-moon-fill", "bi-sun-fill");
     darkModeToggle.innerHTML = `<i class="bi bi-sun-fill"></i>&nbsp;&nbsp;Light Mode`;
   } else {
@@ -76,4 +75,18 @@ darkModeToggle.addEventListener("click", () => {
   }
 });
 
+window.addEventListener("load",()=>{
+  const darkModeState = localStorage.getItem("darkMode");
+  if (darkModeState === "on") {
+    document.body.classList.add("dark-mode-body");
+    document.querySelector(".header-container").classList.add("dark-mode-header");
 
+    const countryCards = document.querySelectorAll(".country-card");
+    countryCards.forEach(card => {
+      card.classList.add("dark-mode-card");
+    });
+    const icon = darkModeToggle.querySelector("i");
+    icon.classList.replace("bi-moon-fill", "bi-sun-fill");
+    darkModeToggle.innerHTML = `<i class="bi bi-sun-fill"></i>&nbsp;&nbsp;Light Mode`;
+  }
+})


### PR DESCRIPTION
This PR addresses the issue where the dark mode toggle was applied only to the main page but did not reflect on the country.html page.
---
### Changes Made:
1)Implemented a dark mode persistence mechanism using localStorage to store the user's preference.
2)Ensured the dark mode styling is applied consistently across pages by checking and applying the darkMode state from localStorage on page load.
3)Updated the darkModeToggle logic to handle multiple page scenarios.